### PR TITLE
Change API `.spec.plan` from `int` type to `string` type

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -37,10 +37,9 @@ type AppSpec struct {
 	// +kubebuilder:validation:Enum=install;update
 	Action string `json:"action,omitempty"`
 
-	// The PVC size of the app (only for certain apps)
+	// The plan of the app (only for certain apps)
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=1
-	Plan int `json:"plan,omitempty"`
+	Plan string `json:"plan,omitempty"`
 }
 
 // JobInfo contains information about each Job we launched under an App

--- a/config/crd/bases/kubemart.civo.com_apps.yaml
+++ b/config/crd/bases/kubemart.civo.com_apps.yaml
@@ -57,9 +57,8 @@ spec:
                 description: The app name e.g. 'wordpress'
                 type: string
               plan:
-                description: The PVC size of the app (only for certain apps)
-                minimum: 1
-                type: integer
+                description: The plan of the app (only for certain apps)
+                type: string
             type: object
           status:
             description: AppStatus defines the observed state of App

--- a/config/samples/app/install/linkerd/app_v1alpha1_linkerd_app.yaml
+++ b/config/samples/app/install/linkerd/app_v1alpha1_linkerd_app.yaml
@@ -1,0 +1,9 @@
+apiVersion: kubemart.civo.com/v1alpha1
+kind: App
+metadata:
+  name: linkerd
+  namespace: kubemart-system
+spec:
+  name: linkerd
+  action: install
+  plan: linkerdviz

--- a/config/samples/app/install/mariadb/app_v1alpha1_mariadb_app.yaml
+++ b/config/samples/app/install/mariadb/app_v1alpha1_mariadb_app.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   name: mariadb
   action: install
-  plan: 5
+  plan: 5Gi

--- a/controllers/app_controller.go
+++ b/controllers/app_controller.go
@@ -303,7 +303,7 @@ func (r *AppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 		// app plan
 		appPlan := appInstance.Spec.Plan
-		if appPlan > 0 {
+		if appPlan != "" {
 			planVariableName, err := utils.GetAppPlanVariableName(appInstance.Spec.Name)
 			if err != nil {
 				return reconcile.Result{}, err // restart reconcile
@@ -313,7 +313,7 @@ func (r *AppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			if !planExists {
 				configs = append(configs, appv1alpha1.Configuration{
 					Key:   planVariableName,
-					Value: fmt.Sprintf("%dGi", appPlan),
+					Value: appPlan,
 				})
 			}
 		}

--- a/controllers/app_controller.go
+++ b/controllers/app_controller.go
@@ -375,7 +375,14 @@ func (r *AppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 
 			if len(depthDependencyPlans) > 0 {
-				dApp.Spec.Plan = utils.GetSmallestAppPlan(depthDependencyPlans)
+				smallestPlanLabel := utils.GetSmallestAppPlan(depthDependencyPlans)
+				smallestPlanValue, err := utils.GetAppPlanValueByLabel(depthDependency, smallestPlanLabel)
+				if err != nil {
+					logger.Error(err, "Failed to get the smallest plan value for app", "app", depthDependency)
+					return reconcile.Result{}, err // restart reconcile
+				}
+
+				dApp.Spec.Plan = smallestPlanValue
 			}
 
 			err = r.Create(context.Background(), dApp, &client.CreateOptions{})

--- a/controllers/app_controller_test.go
+++ b/controllers/app_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	v1alpha1 "github.com/kubemart/kubemart-operator/api/v1alpha1"
+	"github.com/kubemart/kubemart-operator/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -95,9 +96,10 @@ var _ = Describe("App controller\n", func() {
 	Context("When creating a complex (with dependencies) App", func() {
 		ctx := context.Background()
 		appName := "wordpress"
-		planSize := 10 // GiB
+		planSize := "10Gi"
+		planSizeInt := utils.ExtractPlanIntFromPlanStr(planSize)
 		oneGibInBytes := 1073741824
-		planSizeInBytes := planSize * oneGibInBytes
+		planSizeInBytes := planSizeInt * oneGibInBytes
 
 		It("Should create the App CR", func() {
 			app := &v1alpha1.App{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -224,6 +224,28 @@ func GetAppPlanVariableName(appName string) (string, error) {
 	return planVariableNames[0], nil
 }
 
+func GetAppPlanValueByLabel(appName, planLabel string) (string, error) {
+	planValue := ""
+
+	manifest, err := GetAppManifest(appName)
+	if err != nil {
+		return planValue, err
+	}
+
+	for _, plan := range manifest.Plans {
+		if plan.Label == planLabel {
+			confKey, err := GetAppPlanVariableName(appName)
+			if err != nil {
+				return planValue, err
+			}
+
+			planValue = plan.Configuration[confKey].Value
+		}
+	}
+
+	return planValue, nil
+}
+
 // SanitizeDependencyName returns only the 'appname' (string) from 'appname:sizeGB' string.
 // Examples: https://rubular.com/r/5ibwrOnew3vKpf.
 func SanitizeDependencyName(lowerCasedInput string) (string, error) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -318,38 +317,26 @@ func ExtractPlanIntFromPlanStr(input string) (output int) {
 	return output
 }
 
-// GetAppPlans returns sorted app plans e.g. [5,10,20]
-func GetAppPlans(appName string) ([]int, error) {
-	plans := []int{}
+// GetAppPlans returns app plan labels e.g. ["5GB", "10GB", "20GB"]
+func GetAppPlans(appName string) ([]string, error) {
+	plans := []string{}
 	manifest, err := GetAppManifest(appName)
 	if err != nil {
 		return plans, err
 	}
 
 	for _, plan := range manifest.Plans {
-		conf := plan.Configuration
-		keys := reflect.ValueOf(conf).MapKeys()
-		strKeys := make([]string, len(keys))
-		for i := 0; i < len(keys); i++ {
-			strKeys[i] = keys[i].String()
-		}
-
-		for _, key := range strKeys {
-			p := ExtractPlanIntFromPlanStr(conf[key].Value)
-			if p > 0 {
-				plans = append(plans, p)
-			}
-		}
+		label := plan.Label
+		plans = append(plans, label)
 	}
 
-	sort.Ints(plans)
 	return plans, nil
 }
 
-// GetSmallestAppPlan take sorted plans slice e.g. [5,10,20] and return
-// the smallest one e.g. 5 (int)
-func GetSmallestAppPlan(sortedPlans []int) int {
-	return sortedPlans[0]
+// GetSmallestAppPlan take plan labels slice e.g. ["5GB", "10GB", "20GB"]
+// and return the first one e.g. 5GB (string)
+func GetSmallestAppPlan(plans []string) string {
+	return plans[0]
 }
 
 // GetNamespaceFromAppManifest returns the app's namespace from the app's manifest.yaml file

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -379,7 +379,7 @@ func TestExtractPlanIntFromPlanStr9(t *testing.T) {
 
 func TestGetAppPlans1(t *testing.T) {
 	actual, _ := GetAppPlans("mariadb")
-	expected := []int{5, 10, 20}
+	expected := []string{"5GB", "10GB", "20GB"}
 	if !elementsMatch(expected, actual) {
 		t.Errorf("Expected %v but got %v", expected, actual)
 	}
@@ -387,7 +387,7 @@ func TestGetAppPlans1(t *testing.T) {
 
 func TestGetAppPlans2(t *testing.T) {
 	actual, _ := GetAppPlans("cert-manager")
-	expected := []int{}
+	expected := []string{}
 	if !elementsMatch(expected, actual) {
 		t.Errorf("Expected %v but got %v", expected, actual)
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -394,11 +394,12 @@ func TestGetAppPlans2(t *testing.T) {
 }
 
 func TestGetSmallestAppPlan(t *testing.T) {
-	plans := []int{5, 10, 20}
+	plans := []string{"5GB", "10GB", "20GB"}
+	expected := "5GB"
 	actual := GetSmallestAppPlan(plans)
-	expected := 5
+
 	if expected != actual {
-		t.Errorf("Expected %d but actual is %d", expected, actual)
+		t.Errorf("Expecting %+v but got %+v\n", expected, actual)
 	}
 }
 


### PR DESCRIPTION
To give room for custom plans. Example app's _manifest.yaml_ file:

```yaml
name: Linkerd
version: Latest
maintainer: hello@buoyant.io
description: Linkerd is a service mesh, giving you runtime debugging, observability, reliability, and security.
url: https://linkerd.io
category: architecture
plans:
  - label: "Linkerd Minimal"
    configuration:
      LINKERD:
        value: linkerd
  - label: "Linkerd & Jaeger"
    configuration:
      LINKERD:
        value: linkerdjaeger
  - label: "Linkerd with Dashboard"
    configuration:
      LINKERD:
        value: linkerdviz
  - label: "Linkerd with Dashboard & Jaeger"
    configuration:
      LINKERD:
        value: theworks
```